### PR TITLE
Fixes #24 incorrect cache-control header parsing

### DIFF
--- a/lib/src/manager_dio.dart
+++ b/lib/src/manager_dio.dart
@@ -140,8 +140,10 @@ class DioCacheManager {
       // try to get maxAge and maxStale from cacheControl
       var parameters;
       try {
-        parameters = HeaderValue.parse(cacheControl,
-                parameterSeparator: ",", valueSeparator: "=")
+        parameters = HeaderValue.parse(
+                HttpHeaders.cacheControlHeader + ": " + cacheControl,
+                parameterSeparator: ",",
+                valueSeparator: "=")
             .parameters;
       } catch (e) {
         print(e);


### PR DESCRIPTION
As `HeaderValue.parse` expects the header name to be present for parsing to succeed.